### PR TITLE
Fix legacy WF-RAC firmware compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The Operator ID identifies a remote control to the air conditioner. The device a
 
 **Self-register (recommended, no config required).** Leave the `operatorId` field blank. The plugin will generate its own ID, register itself as a new remote on each device on first contact (via `updateAccountInfo`), and persist the ID across restarts. When you remove a device from the plugin's config, the plugin deregisters itself (via `deleteAccountInfo`) so the device's remote slot is freed.
 
+Some early WF-RAC firmware rejects UUID-style operator IDs with HTTP 501 (`Not supported this command`). In self-register mode the plugin detects that exact response, retries once with a 10-digit numeric ID, and persists the accepted ID. Other errors and newer firmware keep the normal UUID path unchanged.
+
 **Mirror an existing remote.** If you'd rather reuse the operator ID of your Smart M-Air app (so the plugin doesn't take its own remote slot), set `operatorId` in the config to that value. In this mode the plugin will not register or deregister anything — it simply impersonates the Smart M-Air app.
 
 To find your Smart M-Air app's Operator ID for the mirror approach, you can do a simple `curl` request to the air conditioner's IP address. The command name must be included in the URL path (`/beaver/command/<command>`).

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint src --max-warnings=0",
-    "test": "npm run lint && npm run build",
+    "test": "npm run lint && npm run build && node --test test/*.test.mjs",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
     "prepublishOnly": "npm run lint && npm run build",

--- a/src/device.ts
+++ b/src/device.ts
@@ -2,6 +2,9 @@ import {Buffer} from 'buffer';
 import https from 'https';
 import {Logging} from 'homebridge';
 import axios from 'axios';
+import {randomInt} from 'crypto';
+
+export const generateLegacyOperatorId = (): string => randomInt(0, 10_000_000_000).toString().padStart(10, '0');
 
 export class DeviceStatus {
   // eslint-disable-next-line max-len
@@ -317,6 +320,10 @@ export class DeviceStatus {
 
     statByte[12] |= this.entrust ? 12 : 8;
 
+    if (!this.coolHotJudge) {
+      statByte[8] |= 8;
+    }
+
     if (this.modelNo === 1) {
       statByte[10] |= this.isVacantProperty ? 1 : 0;
     }
@@ -451,7 +458,7 @@ export class DeviceClient {
   private readonly ipAddress: string;
   private readonly port: number;
 
-  private readonly operatorId: string;
+  private operatorId: string;
   private readonly deviceId: string;
   // airconId may be refreshed after a getDeviceInfo call: some firmware returns
   // an airconId that differs from the MAC, and updateAccountInfo must be called
@@ -467,6 +474,7 @@ export class DeviceClient {
   private nextRequestAfter = 0;
 
   private useHttps: boolean | null = null; // null = not yet detected
+  private legacyOperatorFallbackAttempted = false;
   // Newer WF-RAC firmware (HTTPS on 51443) needs TLS 1.2 with ALPN restricted to http/1.1.
   // Without this Node 24's TLS defaults (TLS 1.3, h2 in ALPN) cause the handshake to fail or hang.
   // The device also only accepts a single connection at a time, hence Connection: close.
@@ -485,6 +493,8 @@ export class DeviceClient {
     airconId: string,
     log: Logging,
     ignoreConnectionErrors: boolean = true,
+    private readonly onLegacyOperatorIdAccepted?: (operatorId: string) => void,
+    private readonly legacyOperatorIdFactory: () => string = generateLegacyOperatorId,
   ) {
     this.ipAddress = ipAddress;
     this.port = port;
@@ -493,6 +503,10 @@ export class DeviceClient {
     this.airconId = airconId;
     this.log = log;
     this.ignoreConnectionErrors = ignoreConnectionErrors;
+  }
+
+  setOperatorId(operatorId: string): void {
+    this.operatorId = operatorId;
   }
 
   public isConnectionError(error: Error): boolean {
@@ -667,6 +681,10 @@ export class DeviceClient {
       this.log.info(`Device ${this.deviceId} (${this.ipAddress}): using HTTPS`);
       return response.data;
     } catch (httpsError) {
+      if (this.isUnsupportedCommandError(httpsError)) {
+        this.useHttps = true;
+        throw httpsError;
+      }
       this.log.debug(`HTTPS failed for ${this.deviceId} (${this.ipAddress}), trying HTTP: ${(httpsError as Error).message}`);
     }
 
@@ -676,35 +694,47 @@ export class DeviceClient {
       this.log.info(`Device ${this.deviceId} (${this.ipAddress}): using HTTP`);
       return response.data;
     } catch (httpError) {
+      if (this.isUnsupportedCommandError(httpError)) {
+        this.useHttps = false;
+        throw httpError;
+      }
       this.log.debug(`HTTP also failed for ${this.deviceId} (${this.ipAddress}): ${(httpError as Error).message}`);
     }
 
     throw new Error(`Unable to connect to device ${this.deviceId} (${this.ipAddress}) via HTTPS or HTTP`);
   }
 
-  async call(command: string, contents: RequestContents|null = null, retries = 3): Promise<DeviceResponse> {
-    let data;
-    if (contents) {
-      data = {
-        apiVer: '1.0',
-        command: command,
-        deviceId: this.deviceId,
-        operatorId: this.operatorId,
-        timestamp: Math.floor(new Date().valueOf() / 1000),
-        contents: contents,
-      };
-    } else {
-      data = {
-        apiVer: '1.0',
-        command: command,
-        deviceId: this.deviceId,
-        operatorId: this.operatorId,
-        timestamp: Math.floor(new Date().valueOf() / 1000),
-      };
+  private isUnsupportedCommandError(error: unknown): boolean {
+    if (!axios.isAxiosError(error) || error.response?.status !== 501) {
+      return false;
     }
-    const body = JSON.stringify(data);
 
-    // Auto-detect protocol on first call
+    const responseText = typeof error.response.data === 'string'
+      ? error.response.data
+      : JSON.stringify(error.response.data ?? '');
+    return /not supported this command/i.test(`${error.message} ${error.response.statusText ?? ''} ${responseText}`);
+  }
+
+  private buildRequestBody(command: string, contents: RequestContents | null, operatorId: string): string {
+    const data = {
+      apiVer: '1.0',
+      command,
+      deviceId: this.deviceId,
+      operatorId,
+      timestamp: Math.floor(Date.now() / 1000),
+      ...(contents ? {contents} : {}),
+    };
+    return JSON.stringify(data);
+  }
+
+  private async callWithOperatorId(
+    command: string,
+    contents: RequestContents | null,
+    operatorId: string,
+    retries: number,
+  ): Promise<DeviceResponse> {
+    const body = this.buildRequestBody(command, contents, operatorId);
+
     if (this.useHttps === null) {
       return await this.detectProtocol(body, command);
     }
@@ -714,15 +744,13 @@ export class DeviceClient {
     let lastError: Error | null = null;
     for (let attempt = 0; attempt <= retries; attempt++) {
       try {
-        // We must use axios, because fetch lowercases the headers, which the device does not like
         const response = await this.sendRequest(url, body, this.useHttps);
         return response.data;
       } catch (error) {
         lastError = error as Error;
 
-        // If this is a connection error and we have retries left, wait and retry
         if (this.isConnectionError(lastError) && attempt < retries) {
-          const backoffMs = Math.min(1000 * Math.pow(2, attempt), 5000); // Exponential backoff, max 5 seconds
+          const backoffMs = Math.min(1000 * Math.pow(2, attempt), 5000);
           const attemptInfo = `attempt ${attempt + 1}/${retries + 1}`;
           this.log.warn(
             `Connection error on ${attemptInfo} for ${this.deviceId}: ${lastError.message}. Retrying in ${backoffMs}ms...`,
@@ -731,12 +759,36 @@ export class DeviceClient {
           continue;
         }
 
-        // If it's not a connection error or we're out of retries, throw
         throw lastError;
       }
     }
 
-    // Should never reach here, but TypeScript needs it
     throw lastError || new Error('Unknown error during API call');
+  }
+
+  async call(command: string, contents: RequestContents|null = null, retries = 3): Promise<DeviceResponse> {
+    try {
+      return await this.callWithOperatorId(command, contents, this.operatorId, retries);
+    } catch (error) {
+      if (!this.onLegacyOperatorIdAccepted || this.legacyOperatorFallbackAttempted ||
+          /^\d{10}$/.test(this.operatorId) || !this.isUnsupportedCommandError(error)) {
+        throw error;
+      }
+
+      this.legacyOperatorFallbackAttempted = true;
+      const previousOperatorId = this.operatorId;
+      const legacyOperatorId = this.legacyOperatorIdFactory();
+      const fallbackContents = contents?.accountId === previousOperatorId
+        ? {...contents, accountId: legacyOperatorId}
+        : contents;
+
+      this.log.warn(
+        `Device ${this.deviceId} rejected the operator ID format; retrying once with a legacy 10-digit operator ID.`,
+      );
+      const response = await this.callWithOperatorId(command, fallbackContents, legacyOperatorId, retries);
+      this.operatorId = legacyOperatorId;
+      this.onLegacyOperatorIdAccepted(legacyOperatorId);
+      return response;
+    }
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -10,6 +10,7 @@ export class HomebridgeMHIWFRACPlatform implements DynamicPlatformPlugin {
   public readonly Characteristic: typeof Characteristic;
 
   public readonly accessories: PlatformAccessory[] = [];
+  private readonly generatedOperatorIdListeners = new Set<(operatorId: string) => void>();
 
   constructor(
     public readonly log: Logging,
@@ -61,6 +62,20 @@ export class HomebridgeMHIWFRACPlatform implements DynamicPlatformPlugin {
     const generated = `homebridge-${randomUUID()}`;
     this.log.info(`No operatorId configured — generated a new one: ${generated}`);
     return { operatorId: generated, selfManaged: true };
+  }
+
+  onGeneratedOperatorIdChanged(listener: (operatorId: string) => void): void {
+    this.generatedOperatorIdListeners.add(listener);
+  }
+
+  persistGeneratedOperatorId(operatorId: string): void {
+    for (const accessory of this.accessories) {
+      accessory.context.generatedOperatorId = operatorId;
+    }
+    for (const listener of this.generatedOperatorIdListeners) {
+      listener(operatorId);
+    }
+    this.log.info(`Persisted legacy-compatible operatorId=${operatorId}`);
   }
 
   configureDevices() {

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -11,7 +11,7 @@ export class WFRACAccessory {
   private readonly deviceId: string;
   private readonly ipAddress: string;
   private readonly port = 51443;
-  private readonly operatorId : string;
+  private operatorId : string;
 
   private device: DeviceClient;
 
@@ -48,7 +48,16 @@ export class WFRACAccessory {
       airconId,
       this.platform.log,
       this.platform.config.ignoreConnectionErrors,
+      selfManaged ? operatorId => this.platform.persistGeneratedOperatorId(operatorId) : undefined,
     );
+
+    if (selfManaged) {
+      this.platform.onGeneratedOperatorIdChanged((updatedOperatorId) => {
+        this.operatorId = updatedOperatorId;
+        this.accessory.context.generatedOperatorId = updatedOperatorId;
+        this.device.setOperatorId(updatedOperatorId);
+      });
+    }
 
     // set accessory information
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
@@ -420,4 +429,3 @@ export class WFRACAccessory {
     });
   }
 }
-

--- a/test/device.test.mjs
+++ b/test/device.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {DeviceClient, DeviceStatus, generateLegacyOperatorId} from '../dist/device.js';
+
+const applyState = (values) => Object.assign(new DeviceStatus(), values);
+
+const baseState = {
+  operation: true,
+  operationMode: 1,
+  airFlow: 0,
+  windDirectionUD: 0,
+  windDirectionLR: 0,
+  presetTemp: 22.5,
+  entrust: false,
+  coolHotJudge: false,
+  modelNo: 0,
+  isVacantProperty: 0,
+  isSelfCleanReset: false,
+  isSelfCleanOperation: false,
+};
+
+const log = {
+  debug() {},
+  error() {},
+  info() {},
+  warn() {},
+};
+
+test('encodes the full cool-mode packet like the Home Assistant reference', () => {
+  const status = applyState(baseState);
+
+  assert.equal(Buffer.from(status.commandToByte()).toString('hex'), '0000eb8fadff0000080000100b0000000000');
+  assert.equal(Buffer.from(DeviceStatus.receiveToBytes(status)).toString('hex'), '000049072dff000008000000010000000000');
+  assert.equal(status.toBase64(), 'AADrj63/AAAIAAAQCwAAAAAAAf/////JDwAASQct/wAACAAAAAEAAAAAAAH/////tf8=');
+});
+
+test('encodes model-specific fields like the Home Assistant reference', () => {
+  const status = applyState({
+    ...baseState,
+    operationMode: 2,
+    airFlow: 3,
+    windDirectionUD: 3,
+    windDirectionLR: 4,
+    presetTemp: 24,
+    entrust: true,
+    coolHotJudge: true,
+    modelNo: 1,
+    isVacantProperty: 1,
+    isSelfCleanReset: true,
+    isSelfCleanOperation: true,
+  });
+
+  assert.equal(status.toBase64(), 'AACzqrD/AAAAAJUTDgAAAAAAAf////+wHgEAESIw/wAAAAABAwQAAAEAAAH/////rWo=');
+});
+
+test('retains the established 25 degree placeholder in fan mode', () => {
+  const status = applyState({
+    ...baseState,
+    operation: false,
+    operationMode: 3,
+    airFlow: 1,
+    windDirectionUD: 1,
+    windDirectionLR: 7,
+    presetTemp: 21,
+    modelNo: 2,
+  });
+
+  assert.equal(status.toBase64(), 'AACuiLL/AAAIAIAWCgAAAAAAAf////9A0gIADAAy/wAACAAABgAAAAAAAAH/////il0=');
+});
+
+test('generates exactly ten decimal digits for legacy firmware', () => {
+  for (let index = 0; index < 100; index++) {
+    assert.match(generateLegacyOperatorId(), /^\d{10}$/);
+  }
+});
+
+test('retries a rejected UUID once and persists the accepted numeric operator ID', async () => {
+  const originalOperatorId = 'homebridge-5ef7431c-03a9-4637-b994-73d252959292';
+  const legacyOperatorId = '1234567890';
+  const accepted = [];
+  const requests = [];
+  const client = new DeviceClient(
+    '192.0.2.1',
+    51443,
+    originalOperatorId,
+    'test-device',
+    'test-aircon',
+    log,
+    false,
+    operatorId => accepted.push(operatorId),
+    () => legacyOperatorId,
+  );
+
+  client.useHttps = false;
+  client.sendRequest = async (_url, body) => {
+    requests.push(JSON.parse(body));
+    if (requests.length === 1) {
+      const error = new Error('Request failed with status code 501');
+      error.isAxiosError = true;
+      error.response = {status: 501, statusText: 'Not Implemented', data: 'Not supported this command'};
+      throw error;
+    }
+    return {
+      data: {
+        command: 'updateAccountInfo',
+        apiVer: '1.0',
+        operatorId: legacyOperatorId,
+        deviceId: 'test-device',
+        timestamp: 0,
+        result: 0,
+        contents: {},
+      },
+    };
+  };
+
+  const response = await client.call('updateAccountInfo', {
+    accountId: originalOperatorId,
+    airconId: 'test-aircon',
+  });
+
+  assert.equal(response.result, 0);
+  assert.deepEqual(requests.map(request => request.operatorId), [originalOperatorId, legacyOperatorId]);
+  assert.deepEqual(requests.map(request => request.contents.accountId), [originalOperatorId, legacyOperatorId]);
+  assert.deepEqual(accepted, [legacyOperatorId]);
+});
+
+test('does not fall back for unrelated HTTP 501 responses', async () => {
+  const client = new DeviceClient(
+    '192.0.2.1', 51443, 'long-operator-id', 'test-device', 'test-aircon', log, false, () => {
+      assert.fail('fallback must not be persisted');
+    },
+  );
+  const error = new Error('Request failed with status code 501');
+  error.isAxiosError = true;
+  error.response = {status: 501, statusText: 'Not Implemented', data: 'Different failure'};
+  client.useHttps = false;
+  client.sendRequest = async () => { throw error; };
+
+  await assert.rejects(client.call('getAirconStat', {airconId: 'test-aircon'}), error);
+});


### PR DESCRIPTION
## Summary

- mirror `CoolHotJudge` into both WF-RAC frames so encoded commands match the known-good Home Assistant implementation
- retry the exact legacy HTTP 501 operator-ID rejection once with a generated 10-digit numeric ID
- persist the numeric ID only after the retry is accepted, and share it across configured accessories
- add full encoded-packet, CRC, and operator fallback regression tests

## Root cause

The Homebridge encoder wrote the `CoolHotJudge` flag (`0x08` in byte 8 when false) only into the receive frame. The Home Assistant WF-RAC encoder writes the flag into both the command and receive frames. Consequently, Homebridge produced internally inconsistent paired frames whenever `CoolHotJudge` was false. Firmware 010 / MCU 131 rejects that command payload with `setAirconStat result=12`.

Separately, early WF-RAC firmware rejects long UUID-style operator IDs at the HTTP command layer with status 501 and `Not supported this command`. A 10-digit numeric ID is accepted.

## Reproduction

Tested configuration:

- `firmType`: `WF-RAC`
- wireless firmware: `010`
- MCU firmware: `131`

1. Send `getAirconStat` with `operatorId=homebridge-5ef7431c-03a9-4637-b994-73d252959292`; the module returns HTTP 501 / `Not supported this command`.
2. Send the same request with `operatorId=1234567890`; `getAirconStat` returns `result=0`.
3. Register the numeric ID with `updateAccountInfo`; `numOfAccount` increases.
4. Encode a state where `CoolHotJudge=false` with the previous Homebridge encoder and call `setAirconStat`; the module returns `result=12`.
5. Add byte 8 bit `0x08` to the command frame as well as the receive frame and recompute its CRC; the encoded packet now matches the known-good Home Assistant vector.

## Protocol comparison

The complete `commandToByte()` and `receiveToBytes()` implementations were compared field by field against `custom_components/mitsubishi_wf_rac/wfrac/rac_parser.py` at `jeatheak/Mitsubishi-WF-RAC-Integration` commit `5ebb99561fb44b4acdeba6c9d8d5777a0ab2fb75`.

All operation, mode, airflow, vertical/horizontal direction, entrust, model, vacant-property, self-clean, suffix, and CRC bytes match for identical states after this fix.

Two differences were found:

1. **Bug:** Homebridge omitted `CoolHotJudge` from byte 8 of the command frame. This change mirrors it into both frames.
2. **Intentional:** in fan mode Homebridge encodes the ignored temperature field as 25 degrees C, while the current Home Assistant integration preserves the reported setpoint. This established normalization is unrelated to the rejected temperature/mode writes and remains unchanged.

The tests pin complete 50-byte base64 payloads, including both CRCs, against vectors generated by the Home Assistant encoder. They also retain a vector for Homebridge's intentional fan-mode normalization.

## Legacy operator-ID fallback

Self-managed registrations continue trying their existing generated UUID-style ID first. Only an Axios response with both HTTP status 501 and the text `Not supported this command` activates the fallback. The request is retried once with exactly 10 decimal digits; for account registration, both top-level `operatorId` and `contents.accountId` are updated. The fallback ID is persisted only after that retry receives an HTTP response and is propagated to all active accessories.

Configured mirror-mode IDs are not changed automatically because replacing one would stop impersonating the configured Smart M-Air account and would require registration as a different remote.

## Backward compatibility

- Newer firmware keeps the existing UUID-style operator ID because it never returns the exact legacy 501 response.
- Other HTTP 501 responses, connection failures, and API errors do not activate fallback.
- Numeric IDs never trigger another fallback.
- The retry is attempted at most once per client.
- All pre-existing frame fields and fan-mode temperature normalization are preserved; only the missing mirrored protocol bit and its command-frame CRC change.

## Validation

`npm test`

- ESLint passes
- TypeScript build passes
- 6 Node regression tests pass
